### PR TITLE
Fix MeasureSearch parmaters

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,8 +21,9 @@ import AIMSim
 project = 'AIMSim'
 copyright = '2022, Jackson Burns, Himaghna Bhattacharjee'
 author = 'Jackson Burns, Himaghna Bhattacharjee'
-
 # The full version, including alpha/beta/rc tags
+
+
 def read(rel_path):
     here = os.path.abspath(os.path.dirname(__file__))
     with codecs.open(os.path.join(here, rel_path), 'r') as fp:
@@ -37,6 +38,7 @@ def get_version(rel_path):
     else:
         raise RuntimeError("Unable to find version string.")
         
+
 release = get_version("../AIMSim/__init__.py")
 
 # -- General configuration ---------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,7 +37,7 @@ def get_version(rel_path):
             return line.split(delim)[1]
     else:
         raise RuntimeError("Unable to find version string.")
-        
+
 
 release = get_version("../AIMSim/__init__.py")
 

--- a/molSim/tasks/measure_search.py
+++ b/molSim/tasks/measure_search.py
@@ -72,8 +72,8 @@ class MeasureSearch(Task):
 
         Args:
             molecule_set_configs (dict): All configurations (except
-                fingerprint_type and similarity_measure) needed to form
-                the moleculeSet.
+                fingerprint_type, fingerprint_params and similarity_measure)
+                needed to form the moleculeSet.
             fingerprint_type (str): Label to indicate which fingerprint to
                 use. If supplied, fingerprint is fixed and optimization
                 carried out over similarity measures. Use None to indicate
@@ -143,7 +143,6 @@ class MeasureSearch(Task):
         else:
             all_similarity_measures = [similarity_measure]
         is_verbose = molecule_set_configs.get("is_verbose", False)
-        n_threads = molecule_set_configs.get("n_workers", 1)
         all_scores = []
         if fingerprint_params is None:
             fingerprint_params = {}
@@ -166,7 +165,8 @@ class MeasureSearch(Task):
                         fingerprint_type=fingerprint_type,
                         fingerprint_params=fingerprint_params,
                         is_verbose=is_verbose,
-                        n_threads=n_threads,
+                        n_threads=molecule_set_configs.get(
+                            'n_threads', 1),
                         sampling_ratio=subsample_subset_size)
                 except (InvalidConfigurationError, ValueError) as e:
                     if is_verbose:

--- a/molSim/tasks/task_manager.py
+++ b/molSim/tasks/task_manager.py
@@ -89,7 +89,7 @@ class TaskManager:
             if fingerprint_type == 'determine':
                 fingerprint_type = None
                 fingerprint_params = {}
-            molecule_set_configs = {
+            measure_search_molset_configs = {
                 'molecule_database_src': molecule_database_src,
                 'molecule_database_src_type': database_src_type,
                 'is_verbose': is_verbose,
@@ -97,7 +97,7 @@ class TaskManager:
             }
 
             best_measure = measure_search(
-                molecule_set_configs=molecule_set_configs,
+                molecule_set_configs=measure_search_molset_configs,
                 similarity_measure=similarity_measure,
                 fingerprint_type=fingerprint_type,
                 fingerprint_params=fingerprint_params,
@@ -110,7 +110,6 @@ class TaskManager:
                   f'and {similarity_measure}.')
 
         sampling_ratio = molecule_set_configs.get("sampling_ratio", 1.)
-
         print(f'Choosing sampling ratio of {sampling_ratio} for tasks')
         self.molecule_set = MoleculeSet(
             molecule_database_src=molecule_database_src,

--- a/molSim/tasks/task_manager.py
+++ b/molSim/tasks/task_manager.py
@@ -89,14 +89,18 @@ class TaskManager:
             if fingerprint_type == 'determine':
                 fingerprint_type = None
                 fingerprint_params = {}
+            molecule_set_configs = {
+                'molecule_database_src': molecule_database_src,
+                'molecule_database_src_type': database_src_type,
+                'is_verbose': is_verbose,
+                'n_threads': n_threads,
+            }
+
             best_measure = measure_search(
+                molecule_set_configs=molecule_set_configs,
                 similarity_measure=similarity_measure,
                 fingerprint_type=fingerprint_type,
                 fingerprint_params=fingerprint_params,
-                molecule_database_src=molecule_database_src,
-                molecule_database_src_type=database_src_type,
-                is_verbose=is_verbose,
-                n_threads=n_threads,
                 subsample_subset_size=subsample_subset_size,
                 show_top=5,
                 only_metric=only_valid_dist)
@@ -106,6 +110,8 @@ class TaskManager:
                   f'and {similarity_measure}.')
 
         sampling_ratio = molecule_set_configs.get("sampling_ratio", 1.)
+
+        print(f'Choosing sampling ratio of {sampling_ratio} for tasks')
         self.molecule_set = MoleculeSet(
             molecule_database_src=molecule_database_src,
             molecule_database_src_type=database_src_type,


### PR DESCRIPTION
Divide parameters explicitly between molecule_set_configs passed as a dictionary and fingerprint_type, fingerprint_params and similarity_measure passed as keyword args.