### PR TITLE
do not use latest buggy ctk update

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,5 @@ rdkit
 psutil
 padelpy
 plotly
-customtkinter
+customtkinter<5.0.0
 tkinter-tooltip


### PR DESCRIPTION
Alternative approach to dealing with inconsistent `CustomTkinter` API - just stick to the older, less buggy version.